### PR TITLE
Add tracked secret processor

### DIFF
--- a/internal/secret/process/path.go
+++ b/internal/secret/process/path.go
@@ -55,7 +55,7 @@ func NewDecryptionPathState(ignoreBothExists bool, repo storage.SecretRepository
 		switch {
 		case encOK && decOK && ignoreBothExists:
 			// Already decrypted, ignore.
-			logger.Warningf("ignoring secret, already decrypted")
+			logger.Warningf("Ignoring secret, already decrypted")
 			return "", nil
 		case encOK && decOK && !ignoreBothExists:
 			// Already decrypted, however we don't care, allow decrypting.
@@ -65,7 +65,7 @@ func NewDecryptionPathState(ignoreBothExists bool, repo storage.SecretRepository
 			return secretID, nil
 		case !encOK && decOK:
 			// Already decrypted, ignore.
-			logger.Warningf("ignoring secret, already decrypted")
+			logger.Warningf("Ignoring secret, already decrypted")
 			return "", nil
 		}
 
@@ -99,11 +99,11 @@ func NewEncryptionPathState(repo storage.SecretRepository, logger log.Logger) ID
 		switch {
 		case encOK && decOK:
 			// Already encrypted, ignore.
-			logger.Warningf("ignoring secret, already encrypted")
+			logger.Warningf("Ignoring secret, already encrypted")
 			return "", nil
 		case encOK && !decOK:
 			// Already encrypted, ignore.
-			logger.Warningf("ignoring secret, already encrypted")
+			logger.Warningf("Ignoring secret, already encrypted")
 			return "", nil
 		case !encOK && decOK:
 			// Allow encrypting.


### PR DESCRIPTION
This secret Processor receives on creating a set of secret IDs, whenever secret is processed, it will search if the secret is in the tracked ones and if not it will error, or ignore depending on the used flag.

This processor is helpful to check if the secrets are in the tracked files and error or if not just ignore them (e.g `untrack` command)