### PR TITLE
On public key load, ignore invalid ones instead of returning an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- When loading public keys, invalid ones will be ignored instead of failing.
+
 ## [v0.3.0] - 2021-03-19
 
 ### Added

--- a/internal/storage/fs/key.go
+++ b/internal/storage/fs/key.go
@@ -94,7 +94,9 @@ func (k keyRepository) ListPublicKeys(ctx context.Context) (*storage.PublicKeyLi
 		for _, data := range dataLines {
 			key, err := k.keyFactory.GetPublicKey(ctx, data)
 			if err != nil {
-				return fmt.Errorf("could not load public key in %q: %w", path, err)
+				// If we can't load a key, don't fail, we try our best.
+				k.logger.WithValues(log.Kv{"key": path}).Warningf("could not load public key: %s", err)
+				continue
 			}
 
 			keys = append(keys, key)


### PR DESCRIPTION
Closes #65 