### PR TITLE
Add a limit of 20 public keys on encryption due to age decryption limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - When loading public keys, invalid ones will be ignored instead of failing.
+- Fail if we have more than 20 recipients on encryption (due to Age decrypt limit).
 
 ## [v0.3.0] - 2021-03-19
 

--- a/internal/secret/encrypt/age/age.go
+++ b/internal/secret/encrypt/age/age.go
@@ -42,6 +42,16 @@ func (encrypter) Encrypt(ctx context.Context, secret model.Secret, keys []model.
 		ageRecipients = append(ageRecipients, aKey.AgeRecipient())
 	}
 
+	// Age has a decrypt limit of 20 recipients.
+	// We don't want the user to encrypt as if this would be ok and then the user
+	// have errors decrypting. More information:
+	// 	- https://github.com/FiloSottile/age/blob/dabc470bfe8fd14ef93dd83e769e609176af461c/age.go#L171
+	//  - https://github.com/FiloSottile/age/issues/139
+	const maxAgeRecipients = 20
+	if len(ageRecipients) > maxAgeRecipients {
+		return nil, fmt.Errorf("age has a max recipients (20) decrypt limit, avoid encrypting")
+	}
+
 	// Encrypt data.
 	var b bytes.Buffer
 	cryptedW, err := age.Encrypt(&b, ageRecipients...)

--- a/internal/secret/encrypt/age/age_test.go
+++ b/internal/secret/encrypt/age/age_test.go
@@ -55,6 +55,20 @@ func TestEncrypter(t *testing.T) {
 			expEncryptErr: true,
 		},
 
+		"Encrypting secrets with more than 20 recipients should fail.": {
+			publicKeys: []model.PublicKey{
+				publicKey1, publicKey1, publicKey1, publicKey1, publicKey1,
+				publicKey1, publicKey1, publicKey1, publicKey1, publicKey1,
+				publicKey1, publicKey1, publicKey1, publicKey1, publicKey1,
+				publicKey1, publicKey1, publicKey1, publicKey1, publicKey1,
+				publicKey1,
+			},
+			secret: model.Secret{
+				DecryptedData: []byte("this is a test secret"),
+			},
+			expEncryptErr: true,
+		},
+
 		"Decrypting secrets without age private key should fail.": {
 			publicKeys: []model.PublicKey{publicKey1},
 			secret: model.Secret{


### PR DESCRIPTION
In order to avoid future undecryptable encrypted files due to Age's 20 recipients limit, we don't allow encrypting with more than 20 recipients.

More information here: https://github.com/FiloSottile/age/issues/139