### PR TITLE
Use multiple private keys to decrypt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+
+- Private key discovery in a directory.
+
 ### Changed
 
 - When loading public keys, invalid ones will be ignored instead of failing.
 - Fail if we have more than 20 recipients on encryption (due to Age decrypt limit).
+- --private-key flag has been deprecated in favor of --private-keys.
+- By default private keys will try to be loaded from `$HOME/.ssh` dir.
+- Use multiple private keys to decrypt, if any of them is able to decrypt it will do it.
 
 ## [v0.3.0] - 2021-03-19
 

--- a/cmd/agebox/commands/helper.go
+++ b/cmd/agebox/commands/helper.go
@@ -1,0 +1,15 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+)
+
+var defaultSSHDir = func() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+
+	return filepath.Join(home, ".ssh")
+}()

--- a/internal/box/cat/cat_test.go
+++ b/internal/box/cat/cat_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/slok/agebox/internal/model"
 	"github.com/slok/agebox/internal/secret/encrypt/encryptmock"
 	"github.com/slok/agebox/internal/secret/process/processmock"
+	"github.com/slok/agebox/internal/storage"
 	"github.com/slok/agebox/internal/storage/storagemock"
 )
 
@@ -53,7 +54,7 @@ func TestCatBox(t *testing.T) {
 			},
 			mock: func(m mocks) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, fmt.Errorf("something"))
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(nil, fmt.Errorf("something"))
 			},
 			expErr: true,
 		},
@@ -64,7 +65,7 @@ func TestCatBox(t *testing.T) {
 			},
 			mock: func(m mocks) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, nil)
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(&storage.PrivateKeyList{}, nil)
 
 				// Processed secret.
 				{
@@ -87,7 +88,7 @@ func TestCatBox(t *testing.T) {
 			},
 			mock: func(m mocks) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, nil)
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(&storage.PrivateKeyList{}, nil)
 
 				// Processed secret.
 				{
@@ -108,7 +109,7 @@ func TestCatBox(t *testing.T) {
 			mock: func(m mocks) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
 				m.msp.On("ProcessID", mock.Anything, "ignored").Once().Return("", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, nil)
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(&storage.PrivateKeyList{}, nil)
 
 				// Processed secret.
 				{
@@ -131,7 +132,7 @@ func TestCatBox(t *testing.T) {
 			},
 			mock: func(m mocks) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, nil)
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(&storage.PrivateKeyList{}, nil)
 
 				// Processed secret.
 				{
@@ -147,7 +148,7 @@ func TestCatBox(t *testing.T) {
 			},
 			mock: func(m mocks) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, nil)
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(&storage.PrivateKeyList{}, nil)
 
 				// Processed secret.
 				{
@@ -164,7 +165,7 @@ func TestCatBox(t *testing.T) {
 			},
 			mock: func(m mocks) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, nil)
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(&storage.PrivateKeyList{}, nil)
 
 				// Processed secret.
 				{
@@ -181,7 +182,7 @@ func TestCatBox(t *testing.T) {
 			},
 			mock: func(m mocks) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, nil)
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(&storage.PrivateKeyList{}, nil)
 
 				// Processed secret.
 				{
@@ -199,7 +200,7 @@ func TestCatBox(t *testing.T) {
 			},
 			mock: func(m mocks) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, nil)
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(&storage.PrivateKeyList{}, nil)
 
 				// Processed secret.
 				{

--- a/internal/box/decrypt/decrypt_test.go
+++ b/internal/box/decrypt/decrypt_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/slok/agebox/internal/model"
 	"github.com/slok/agebox/internal/secret/encrypt/encryptmock"
 	"github.com/slok/agebox/internal/secret/process/processmock"
+	"github.com/slok/agebox/internal/storage"
 	"github.com/slok/agebox/internal/storage/storagemock"
 )
 
@@ -45,13 +46,13 @@ func TestDecryptBox(t *testing.T) {
 			expErr: true,
 		},
 
-		"Having an error while retrieving private key, it should fail.": {
+		"Having an error while retrieving private keys, it should fail.": {
 			req: decrypt.DecryptBoxRequest{
 				SecretIDs: []string{"secret1"},
 			},
 			mock: func(m mocks) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, fmt.Errorf("something"))
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(nil, fmt.Errorf("something"))
 			},
 			expErr: true,
 		},
@@ -62,7 +63,7 @@ func TestDecryptBox(t *testing.T) {
 			},
 			mock: func(m mocks) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, nil)
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(&storage.PrivateKeyList{}, nil)
 
 				// Processed secret.
 				{
@@ -84,7 +85,7 @@ func TestDecryptBox(t *testing.T) {
 			mock: func(m mocks) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
 				m.msp.On("ProcessID", mock.Anything, "ignored").Once().Return("", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, nil)
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(&storage.PrivateKeyList{}, nil)
 
 				// Processed secret.
 				{
@@ -111,7 +112,7 @@ func TestDecryptBox(t *testing.T) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
 				m.msp.On("ProcessID", mock.Anything, "wrongsecret1").Once().Return("wrongsecret1", nil)
 				m.msp.On("ProcessID", mock.Anything, "secret2").Once().Return("secret2", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, nil)
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(&storage.PrivateKeyList{}, nil)
 
 				// Secret 1.
 				{
@@ -149,7 +150,7 @@ func TestDecryptBox(t *testing.T) {
 			},
 			mock: func(m mocks) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, nil)
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(&storage.PrivateKeyList{}, nil)
 
 				// Processed secret.
 				{
@@ -165,7 +166,7 @@ func TestDecryptBox(t *testing.T) {
 			},
 			mock: func(m mocks) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, nil)
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(&storage.PrivateKeyList{}, nil)
 
 				// Processed secret.
 				{
@@ -182,7 +183,7 @@ func TestDecryptBox(t *testing.T) {
 			},
 			mock: func(m mocks) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, nil)
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(&storage.PrivateKeyList{}, nil)
 
 				// Processed secret.
 				{

--- a/internal/box/reencrypt/reencrypt_test.go
+++ b/internal/box/reencrypt/reencrypt_test.go
@@ -52,7 +52,7 @@ func TestReencryptBox(t *testing.T) {
 			},
 			mock: func(m mocks) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, fmt.Errorf("something"))
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(nil, fmt.Errorf("something"))
 			},
 			expErr: true,
 		},
@@ -63,7 +63,7 @@ func TestReencryptBox(t *testing.T) {
 			},
 			mock: func(m mocks) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, nil)
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(&storage.PrivateKeyList{}, nil)
 				m.mkr.On("ListPublicKeys", mock.Anything).Once().Return(nil, fmt.Errorf("something"))
 			},
 			expErr: true,
@@ -75,7 +75,7 @@ func TestReencryptBox(t *testing.T) {
 			},
 			mock: func(m mocks) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, nil)
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(&storage.PrivateKeyList{}, nil)
 				m.mkr.On("ListPublicKeys", mock.Anything).Once().Return(&storage.PublicKeyList{}, nil)
 
 				// Processed secret.
@@ -103,7 +103,7 @@ func TestReencryptBox(t *testing.T) {
 			},
 			mock: func(m mocks) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, nil)
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(&storage.PrivateKeyList{}, nil)
 				m.mkr.On("ListPublicKeys", mock.Anything).Once().Return(&storage.PublicKeyList{}, nil)
 
 				// Processed secret.
@@ -128,7 +128,7 @@ func TestReencryptBox(t *testing.T) {
 			mock: func(m mocks) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
 				m.msp.On("ProcessID", mock.Anything, "ignored").Once().Return("", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, nil)
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(&storage.PrivateKeyList{}, nil)
 				m.mkr.On("ListPublicKeys", mock.Anything).Once().Return(&storage.PublicKeyList{}, nil)
 
 				// Processed secret.
@@ -158,7 +158,7 @@ func TestReencryptBox(t *testing.T) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
 				m.msp.On("ProcessID", mock.Anything, "wrongsecret1").Once().Return("wrongsecret1", nil)
 				m.msp.On("ProcessID", mock.Anything, "secret2").Once().Return("secret2", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, nil)
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(&storage.PrivateKeyList{}, nil)
 				m.mkr.On("ListPublicKeys", mock.Anything).Once().Return(&storage.PublicKeyList{}, nil)
 
 				// Secret 1.

--- a/internal/box/validate/validate_test.go
+++ b/internal/box/validate/validate_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/slok/agebox/internal/model"
 	"github.com/slok/agebox/internal/secret/encrypt/encryptmock"
 	"github.com/slok/agebox/internal/secret/process/processmock"
+	"github.com/slok/agebox/internal/storage"
 	"github.com/slok/agebox/internal/storage/storagemock"
 )
 
@@ -52,7 +53,7 @@ func TestValidateBox(t *testing.T) {
 			},
 			mock: func(m mocks) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, fmt.Errorf("something"))
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(nil, fmt.Errorf("something"))
 			},
 			expErr: true,
 		},
@@ -64,7 +65,7 @@ func TestValidateBox(t *testing.T) {
 			},
 			mock: func(m mocks) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, nil)
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(&storage.PrivateKeyList{}, nil)
 
 				// Processed secret.
 				{
@@ -95,7 +96,7 @@ func TestValidateBox(t *testing.T) {
 			mock: func(m mocks) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
 				m.msp.On("ProcessID", mock.Anything, "ignored").Once().Return("", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, nil)
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(&storage.PrivateKeyList{}, nil)
 
 				// Processed secret.
 				{
@@ -121,7 +122,7 @@ func TestValidateBox(t *testing.T) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
 				m.msp.On("ProcessID", mock.Anything, "wrongsecret1").Once().Return("wrongsecret1", nil)
 				m.msp.On("ProcessID", mock.Anything, "secret2").Once().Return("secret2", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, nil)
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(&storage.PrivateKeyList{}, nil)
 
 				// Secret 1.
 				{
@@ -156,7 +157,7 @@ func TestValidateBox(t *testing.T) {
 			},
 			mock: func(m mocks) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, nil)
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(&storage.PrivateKeyList{}, nil)
 
 				// Processed secret.
 				{
@@ -173,7 +174,7 @@ func TestValidateBox(t *testing.T) {
 			},
 			mock: func(m mocks) {
 				m.msp.On("ProcessID", mock.Anything, "secret1").Once().Return("secret1", nil)
-				m.mkr.On("GetPrivateKey", mock.Anything).Once().Return(nil, nil)
+				m.mkr.On("ListPrivateKeys", mock.Anything).Once().Return(&storage.PrivateKeyList{}, nil)
 
 				// Processed secret.
 				{

--- a/internal/secret/encrypt/age/age_test.go
+++ b/internal/secret/encrypt/age/age_test.go
@@ -33,7 +33,7 @@ func getAgePublicKey(s string) model.PublicKey {
 func TestEncrypter(t *testing.T) {
 	tests := map[string]struct {
 		publicKeys    []model.PublicKey
-		privateKey    model.PrivateKey
+		privateKeys   []model.PrivateKey
 		secret        model.Secret
 		expSecret     model.Secret
 		expEncryptErr bool
@@ -78,16 +78,24 @@ func TestEncrypter(t *testing.T) {
 		},
 
 		"Encrypt/decryption should work if the private and public keys are compatible.": {
-			publicKeys: []model.PublicKey{publicKey1},
-			privateKey: privateKey1,
+			publicKeys:  []model.PublicKey{publicKey1},
+			privateKeys: []model.PrivateKey{privateKey1},
 			secret: model.Secret{
 				DecryptedData: []byte("this is a test secret"),
 			},
 		},
 
 		"Encrypt/decryption should work if the private and public keys are compatible (multiple public keys).": {
-			publicKeys: []model.PublicKey{publicKey1, publicKey2},
-			privateKey: privateKey2,
+			publicKeys:  []model.PublicKey{publicKey1, publicKey2},
+			privateKeys: []model.PrivateKey{privateKey2},
+			secret: model.Secret{
+				DecryptedData: []byte("this is a test secret"),
+			},
+		},
+
+		"Encrypt/decryption should work if the private and public keys are compatible (multiple private keys).": {
+			publicKeys:  []model.PublicKey{publicKey2},
+			privateKeys: []model.PrivateKey{privateKey1, privateKey2},
 			secret: model.Secret{
 				DecryptedData: []byte("this is a test secret"),
 			},
@@ -112,7 +120,7 @@ func TestEncrypter(t *testing.T) {
 			secret := model.Secret{
 				EncryptedData: tmpSecret.EncryptedData,
 			}
-			gotSecret, err := encryptage.Encrypter.Decrypt(context.TODO(), secret, test.privateKey)
+			gotSecret, err := encryptage.Encrypter.Decrypt(context.TODO(), secret, test.privateKeys)
 			if test.expDecryptErr {
 				require.Error(err)
 				return

--- a/internal/secret/encrypt/encrypt.go
+++ b/internal/secret/encrypt/encrypt.go
@@ -9,7 +9,7 @@ import (
 // Encrypter knows how to encrypt and decrypt secrets.
 type Encrypter interface {
 	Encrypt(ctx context.Context, secret model.Secret, keys []model.PublicKey) (*model.Secret, error)
-	Decrypt(ctx context.Context, secret model.Secret, key model.PrivateKey) (*model.Secret, error)
+	Decrypt(ctx context.Context, secret model.Secret, keys []model.PrivateKey) (*model.Secret, error)
 }
 
 //go:generate mockery --case underscore --output encryptmock --outpkg encryptmock --name Encrypter

--- a/internal/secret/encrypt/encryptmock/encrypter.go
+++ b/internal/secret/encrypt/encryptmock/encrypter.go
@@ -15,13 +15,13 @@ type Encrypter struct {
 	mock.Mock
 }
 
-// Decrypt provides a mock function with given fields: ctx, secret, key
-func (_m *Encrypter) Decrypt(ctx context.Context, secret model.Secret, key model.PrivateKey) (*model.Secret, error) {
-	ret := _m.Called(ctx, secret, key)
+// Decrypt provides a mock function with given fields: ctx, secret, keys
+func (_m *Encrypter) Decrypt(ctx context.Context, secret model.Secret, keys []model.PrivateKey) (*model.Secret, error) {
+	ret := _m.Called(ctx, secret, keys)
 
 	var r0 *model.Secret
-	if rf, ok := ret.Get(0).(func(context.Context, model.Secret, model.PrivateKey) *model.Secret); ok {
-		r0 = rf(ctx, secret, key)
+	if rf, ok := ret.Get(0).(func(context.Context, model.Secret, []model.PrivateKey) *model.Secret); ok {
+		r0 = rf(ctx, secret, keys)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Secret)
@@ -29,8 +29,8 @@ func (_m *Encrypter) Decrypt(ctx context.Context, secret model.Secret, key model
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, model.Secret, model.PrivateKey) error); ok {
-		r1 = rf(ctx, secret, key)
+	if rf, ok := ret.Get(1).(func(context.Context, model.Secret, []model.PrivateKey) error); ok {
+		r1 = rf(ctx, secret, keys)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/internal/storage/fs/key.go
+++ b/internal/storage/fs/key.go
@@ -15,20 +15,20 @@ import (
 )
 
 type keyRepository struct {
-	publicKeysPath string
-	privateKeyPath string
-	keyFactory     key.Factory
-	fileManager    FileManager
-	logger         log.Logger
+	publicKeysPath  string
+	privateKeysPath string
+	keyFactory      key.Factory
+	fileManager     FileManager
+	logger          log.Logger
 }
 
 // KeyRepositoryConfig is the configuration of the key repository.
 type KeyRepositoryConfig struct {
-	PublicKeysPath string
-	PrivateKeyPath string
-	KeyFactory     key.Factory
-	FileManager    FileManager
-	Logger         log.Logger
+	PublicKeysPath  string
+	PrivateKeysPath string
+	KeyFactory      key.Factory
+	FileManager     FileManager
+	Logger          log.Logger
 }
 
 func (c *KeyRepositoryConfig) defaults() error {
@@ -37,7 +37,7 @@ func (c *KeyRepositoryConfig) defaults() error {
 	}
 
 	c.PublicKeysPath = filepath.Clean(c.PublicKeysPath)
-	c.PrivateKeyPath = filepath.Clean(c.PrivateKeyPath)
+	c.PrivateKeysPath = filepath.Clean(c.PrivateKeysPath)
 
 	if c.FileManager == nil {
 		c.FileManager = defaultFileManager
@@ -61,11 +61,11 @@ func NewKeyRepository(config KeyRepositoryConfig) (storage.KeyRepository, error)
 	}
 
 	return &keyRepository{
-		publicKeysPath: config.PublicKeysPath,
-		privateKeyPath: config.PrivateKeyPath,
-		keyFactory:     config.KeyFactory,
-		fileManager:    config.FileManager,
-		logger:         config.Logger,
+		publicKeysPath:  config.PublicKeysPath,
+		privateKeysPath: config.PrivateKeysPath,
+		keyFactory:      config.KeyFactory,
+		fileManager:     config.FileManager,
+		logger:          config.Logger,
 	}, nil
 }
 
@@ -116,7 +116,7 @@ func (k keyRepository) ListPublicKeys(ctx context.Context) (*storage.PublicKeyLi
 
 func (k keyRepository) ListPrivateKeys(ctx context.Context) (*storage.PrivateKeyList, error) {
 	keys := []model.PrivateKey{}
-	err := k.fileManager.WalkDir(ctx, k.privateKeyPath, fs.WalkDirFunc(func(path string, d fs.DirEntry, err error) error {
+	err := k.fileManager.WalkDir(ctx, k.privateKeysPath, fs.WalkDirFunc(func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -154,14 +154,14 @@ func (k keyRepository) ListPrivateKeys(ctx context.Context) (*storage.PrivateKey
 }
 
 func (k keyRepository) GetPrivateKey(ctx context.Context) (model.PrivateKey, error) {
-	data, err := k.fileManager.ReadFile(ctx, k.privateKeyPath)
+	data, err := k.fileManager.ReadFile(ctx, k.privateKeysPath)
 	if err != nil {
-		return nil, fmt.Errorf("could not load private key %q data from file: %w", k.privateKeyPath, err)
+		return nil, fmt.Errorf("could not load private key %q data from file: %w", k.privateKeysPath, err)
 	}
 
 	key, err := k.keyFactory.GetPrivateKey(ctx, data)
 	if err != nil {
-		return nil, fmt.Errorf("could not load private key in %q: %w", k.privateKeyPath, err)
+		return nil, fmt.Errorf("could not load private key in %q: %w", k.privateKeysPath, err)
 	}
 
 	k.logger.Infof("Loaded private key")

--- a/internal/storage/fs/key_test.go
+++ b/internal/storage/fs/key_test.go
@@ -42,7 +42,7 @@ func TestGetPrivateKey(t *testing.T) {
 	}{
 		"Missing private key should fail.": {
 			config: storagefs.KeyRepositoryConfig{
-				PrivateKeyPath: "test/key1",
+				PrivateKeysPath: "test/key1",
 			},
 			mock: func(mr *fsmock.FileManager, mf *keymock.Factory) {
 				mr.On("ReadFile", mock.Anything, "test/key1").Once().Return(nil, fmt.Errorf("something"))
@@ -52,7 +52,7 @@ func TestGetPrivateKey(t *testing.T) {
 
 		"Loading an existing key should load the key.": {
 			config: storagefs.KeyRepositoryConfig{
-				PrivateKeyPath: "test/key1",
+				PrivateKeysPath: "test/key1",
 			},
 			mock: func(mr *fsmock.FileManager, mf *keymock.Factory) {
 				mr.On("ReadFile", mock.Anything, "test/key1").Once().Return([]byte("key1data"), nil)
@@ -63,7 +63,7 @@ func TestGetPrivateKey(t *testing.T) {
 
 		"Loading an existing key error should fail.": {
 			config: storagefs.KeyRepositoryConfig{
-				PrivateKeyPath: "test/key1",
+				PrivateKeysPath: "test/key1",
 			},
 			mock: func(mr *fsmock.FileManager, mf *keymock.Factory) {
 				mr.On("ReadFile", mock.Anything, "test/key1").Once().Return([]byte("key1data"), nil)
@@ -283,7 +283,7 @@ func TestListPrivateKeys(t *testing.T) {
 	}{
 		"Not having any private key should not fail.": {
 			config: storagefs.KeyRepositoryConfig{
-				PrivateKeyPath: "test/keys",
+				PrivateKeysPath: "test/keys",
 			},
 			mock: func(mr *fsmock.FileManager, mf *keymock.Factory) {
 				mr.On("WalkDir", mock.Anything, "test/keys", mock.Anything).Once().Return(nil)
@@ -293,7 +293,7 @@ func TestListPrivateKeys(t *testing.T) {
 
 		"Having a single key at root should load the key.": {
 			config: storagefs.KeyRepositoryConfig{
-				PrivateKeyPath: "test/keys",
+				PrivateKeysPath: "test/keys",
 			},
 			mock: func(mr *fsmock.FileManager, mf *keymock.Factory) {
 				mr.On("WalkDir", mock.Anything, "test/keys", mock.Anything).Once().Return(nil).Run(func(args mock.Arguments) {
@@ -316,7 +316,7 @@ func TestListPrivateKeys(t *testing.T) {
 
 		"Having valid and invalid keys, should ignore the invalid ones.": {
 			config: storagefs.KeyRepositoryConfig{
-				PrivateKeyPath: "test/keys",
+				PrivateKeysPath: "test/keys",
 			},
 			mock: func(mr *fsmock.FileManager, mf *keymock.Factory) {
 				mr.On("WalkDir", mock.Anything, "test/keys", mock.Anything).Once().Return(nil).Run(func(args mock.Arguments) {
@@ -357,7 +357,7 @@ func TestListPrivateKeys(t *testing.T) {
 
 		"Having an error while loading a key should fail.": {
 			config: storagefs.KeyRepositoryConfig{
-				PrivateKeyPath: "test/keys",
+				PrivateKeysPath: "test/keys",
 			},
 			mock: func(mr *fsmock.FileManager, mf *keymock.Factory) {
 				mr.On("WalkDir", mock.Anything, "test/keys", mock.Anything).Once().Return(fmt.Errorf("something"))
@@ -367,7 +367,7 @@ func TestListPrivateKeys(t *testing.T) {
 
 		"Having multiple keys at root should load the keys.": {
 			config: storagefs.KeyRepositoryConfig{
-				PrivateKeyPath: "test/keys",
+				PrivateKeysPath: "test/keys",
 			},
 			mock: func(mr *fsmock.FileManager, mf *keymock.Factory) {
 				mr.On("WalkDir", mock.Anything, "test/keys", mock.Anything).Once().Return(nil).Run(func(args mock.Arguments) {


### PR DESCRIPTION
Closes #68  

This PR adds support to decrypt with multiple private keys. this involves several things:

- Discovery of private keys from a path.
- Try N private keys on decrypt action (test all until one success).
- By default load private keys from `$HOME/.ssh`.

Affects the commands:

- `decrypt`
- `reencrypt`
- `cat`
- `validate`
