### PR TITLE
Remove 20 public keys limit on encryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Remove the 20 public key encryption limit as Age has removed the decrypt limits.
+
 ## [v0.4.0] - 2021-03-25
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/slok/agebox
 go 1.16
 
 require (
-	filippo.io/age v1.0.0-rc.1
+	filippo.io/age v1.0.0-rc.1.0.20210502224421-85763d390a45
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20210208195552-ff826a37aa15 // indirect
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
-filippo.io/age v1.0.0-rc.1 h1:jQ+dz16Xxx3W/WY+YS0J96nVAAidLHO3kfQe0eOmKgI=
-filippo.io/age v1.0.0-rc.1/go.mod h1:Vvd9IlwNo4Au31iqNZeZVnYtGcOf/wT4mtvZQ2ODlSk=
+filippo.io/age v1.0.0-rc.1.0.20210502224421-85763d390a45 h1:G98N5lksYhIjJvgEn4tKr1cj105wMpWXxwc76B4WtEs=
+filippo.io/age v1.0.0-rc.1.0.20210502224421-85763d390a45/go.mod h1:UjINLBMeA60aGZkHCGsmDzKcaXoTTzpvrqQM+Vo3YHU=
+filippo.io/edwards25519 v1.0.0-beta.3 h1:WQxB0FH5NzrhciInJ30bgL3soLng3AbdI651yQuVlCs=
+filippo.io/edwards25519 v1.0.0-beta.3/go.mod h1:X+pm78QAUPtFLi1z9PYIlS/bdDnvbCOGKtZ+ACWEf7o=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20210208195552-ff826a37aa15 h1:AUNCr9CiJuwrRYS3XieqF+Z9B9gNxo/eANAJCF2eiN4=

--- a/internal/secret/encrypt/age/age.go
+++ b/internal/secret/encrypt/age/age.go
@@ -42,16 +42,6 @@ func (encrypter) Encrypt(ctx context.Context, secret model.Secret, keys []model.
 		ageRecipients = append(ageRecipients, aKey.AgeRecipient())
 	}
 
-	// Age has a decrypt limit of 20 recipients.
-	// We don't want the user to encrypt as if this would be ok and then the user
-	// have errors decrypting. More information:
-	// 	- https://github.com/FiloSottile/age/blob/dabc470bfe8fd14ef93dd83e769e609176af461c/age.go#L171
-	//  - https://github.com/FiloSottile/age/issues/139
-	const maxAgeRecipients = 20
-	if len(ageRecipients) > maxAgeRecipients {
-		return nil, fmt.Errorf("age has a max recipients (20) decrypt limit, avoid encrypting")
-	}
-
 	// Encrypt data.
 	var b bytes.Buffer
 	cryptedW, err := age.Encrypt(&b, ageRecipients...)

--- a/internal/secret/encrypt/age/age_test.go
+++ b/internal/secret/encrypt/age/age_test.go
@@ -55,20 +55,6 @@ func TestEncrypter(t *testing.T) {
 			expEncryptErr: true,
 		},
 
-		"Encrypting secrets with more than 20 recipients should fail.": {
-			publicKeys: []model.PublicKey{
-				publicKey1, publicKey1, publicKey1, publicKey1, publicKey1,
-				publicKey1, publicKey1, publicKey1, publicKey1, publicKey1,
-				publicKey1, publicKey1, publicKey1, publicKey1, publicKey1,
-				publicKey1, publicKey1, publicKey1, publicKey1, publicKey1,
-				publicKey1,
-			},
-			secret: model.Secret{
-				DecryptedData: []byte("this is a test secret"),
-			},
-			expEncryptErr: true,
-		},
-
 		"Decrypting secrets without age private key should fail.": {
 			publicKeys: []model.PublicKey{publicKey1},
 			secret: model.Secret{


### PR DESCRIPTION
Age removed the [decryption 20 private key limit](https://github.com/FiloSottile/age/issues/139) in https://github.com/FiloSottile/age/commit/85763d390a45b546ad2ac34a5e3e09ccd047c6df, so we don't longer need the encryption limit that we added on https://github.com/slok/agebox/pull/67