### PR TITLE
update gopkg.in/yaml.v2 to v2.2.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.1.0 // indirect
 	golang.org/x/sys v0.0.0-20210903071746-97244b99971b // indirect
-	gopkg.in/yaml.v2 v2.2.2 // indirect
+	gopkg.in/yaml.v2 v2.2.8 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -38,7 +38,8 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQ
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Fixes the following vulnerabilities found during a scan:

https://pkg.go.dev/vuln/GO-2022-0956
https://pkg.go.dev/vuln/GO-2021-0061
https://pkg.go.dev/vuln/GO-2020-0036

```
Checking nixpkg agebox
Scanning your code and 182 packages across 17 dependent modules for known vulnerabilities...

=== Symbol Results ===

Vulnerability #1: GO-2022-0956
    Excessive resource consumption in gopkg.in/yaml.v2
  More info: https://pkg.go.dev/vuln/GO-2022-0956
  Module: gopkg.in/yaml.v2
    Found in: gopkg.in/yaml.v2@v2.2.2
    Fixed in: gopkg.in/yaml.v2@v2.2.4
    Example traces found:
      #1: internal/storage/fs/track.go:74:22: fs.TrackRepository.GetSecretRegistry calls yaml.Unmarshal, which eventually calls yaml.Unmarshal

Vulnerability #2: GO-2021-0061
    Denial of service in gopkg.in/yaml.v2
  More info: https://pkg.go.dev/vuln/GO-2021-0061
  Module: gopkg.in/yaml.v2
    Found in: gopkg.in/yaml.v2@v2.2.2
    Fixed in: gopkg.in/yaml.v2@v2.2.3
    Example traces found:
      #1: internal/storage/fs/track.go:74:22: fs.TrackRepository.GetSecretRegistry calls yaml.Unmarshal, which eventually calls yaml.Unmarshal

Vulnerability #3: GO-2020-0036
    Excessive resource consumption in YAML parsing in gopkg.in/yaml.v2
  More info: https://pkg.go.dev/vuln/GO-2020-0036
  Module: gopkg.in/yaml.v2
    Found in: gopkg.in/yaml.v2@v2.2.2
    Fixed in: gopkg.in/yaml.v2@v2.2.8
    Example traces found:
      #1: internal/storage/fs/track.go:74:22: fs.TrackRepository.GetSecretRegistry calls yaml.Unmarshal, which eventually calls yaml.Unmarshal

Your code is affected by 3 vulnerabilities from 1 module.
This scan also found 5 vulnerabilities in packages you import and 0
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
Use '-show verbose' for more details.
```